### PR TITLE
Fix compatibility with Kigkonsult Icalcreator 2.39+

### DIFF
--- a/src/Resources/contao/classes/CalendarExport.php
+++ b/src/Resources/contao/classes/CalendarExport.php
@@ -135,10 +135,10 @@ class CalendarExport extends \Backend
         }
 
         $ical = new Vcalendar();
-        $ical->setMethod('PUBLISH');
-        $ical->setXprop("x-wr-calname", $title);
-        $ical->setXprop("X-WR-CALDESC", $description);
-        $ical->setXprop("X-WR-TIMEZONE", $GLOBALS['TL_CONFIG']['timeZone']);
+        $ical->setMethod(Vcalendar::PUBLISH);
+        $ical->setXprop(Vcalendar::X_WR_CALNAME, $title);
+        $ical->setXprop(Vcalendar::X_WR_CALDESC, $description);
+        $ical->setXprop(Vcalendar::X_WR_TIMEZONE, $GLOBALS['TL_CONFIG']['timeZone']);
         $time = time();
 
         foreach ($arrCalendars as $id) {

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -917,6 +917,9 @@ class CalendarImport extends \Backend
                     $arrFields['repeatEnd'] = $this->getRepeatEnd($arrFields, $rrule, $repeatEach);
                 }
 
+                if (!isset($foundevents[$uid])) {
+                    $foundevents[$uid] = 0;
+                }
                 $foundevents[$uid]++;
 
                 if ($foundevents[$uid] <= 1) {

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -120,9 +120,9 @@ class CalendarImport extends \Backend
     public function importFromWebICS($pid, $url, $startDate, $endDate, $timezone, $proxy, $benutzerpw, $port)
     {
         $this->cal = new Vcalendar();
-        $this->cal->setProperty('method', 'PUBLISH');
-        $this->cal->setProperty("x-wr-calname", $this->strTitle);
-        $this->cal->setProperty("X-WR-CALDESC", $this->strTitle);
+        $this->cal->setMethod(Vcalendar::PUBLISH);
+        $this->cal->setXprop(Vcalendar::X_WR_CALNAME, $this->strTitle);
+        $this->cal->setXprop(Vcalendar::X_WR_CALDESC, $this->strTitle);
 
         /* start parse of local file */
         $filename = $this->downloadURLToTempFile($url, $proxy, $benutzerpw, $port);
@@ -137,7 +137,7 @@ class CalendarImport extends \Backend
             \System::log($e->getMessage(), __METHOD__, TL_ERROR);
             return;
         }
-        $tz = $this->cal->getProperty('X-WR-TIMEZONE');
+        $tz = $this->cal->getProperty(Vcalendar::X_WR_TIMEZONE);
 
         if (!is_array($tz) || strlen($tz[1]) == 0) {
             $tz = $timezone;
@@ -678,9 +678,9 @@ class CalendarImport extends \Backend
     ) {
         $pid = $dc->id;
         $this->cal = new Vcalendar();
-        $this->cal->setProperty('method', 'PUBLISH');
-        $this->cal->setProperty("x-wr-calname", $this->strTitle);
-        $this->cal->setProperty("X-WR-CALDESC", $this->strTitle);
+        $this->cal->setMethod(Vcalendar::PUBLISH);
+        $this->cal->setXprop(Vcalendar::X_WR_CALNAME, $this->strTitle);
+        $this->cal->setXprop(Vcalendar::X_WR_CALDESC, $this->strTitle);
 
         /* start parse of local file */
         $this->cal->setConfig('directory', TL_ROOT . '/' . dirname($filename));
@@ -691,7 +691,7 @@ class CalendarImport extends \Backend
             \Message::addError($e->getMessage());
             $this->redirect(str_replace('&key=import', '', \Environment::get('request')));
         }
-        $tz = $this->cal->getProperty('X-WR-TIMEZONE');
+        $tz = $this->cal->getProperty(Vcalendar::X_WR_TIMEZONE);
 
         if ($timeshift == 0) {
             if (is_array($tz) && strlen($tz[1]) && strcmp($tz[1], $GLOBALS['TL_CONFIG']['timeZone']) != 0) {

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -1020,7 +1020,7 @@ class CalendarImport extends \Backend
         $this->Template->hrefBack = ampersand(str_replace('&key=import', '', \Environment::get('request')));
         $this->Template->goBack = $GLOBALS['TL_LANG']['MSC']['goBack'];
         $this->Template->headline = $GLOBALS['TL_LANG']['MSC']['import_calendar'][0];
-        $this->Template->request = ampersand(\Environment::get('request'), ENCODE_AMPERSANDS);
+        $this->Template->request = ampersand(\Environment::get('request'));
         $this->Template->submit = specialchars($GLOBALS['TL_LANG']['tl_calendar_events']['proceed'][0]);
 
         return $this->Template->parse();

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -868,7 +868,7 @@ class CalendarImport extends \Backend
                 $arrFields['addTime'] = '';
                 $arrFields['endDate'] = 0;
                 $arrFields['endTime'] = 0;
-                $dtStartTz = $tz[1];
+                $timezone = $tz[1];
 
                 if ($dtstart instanceof \DateTime && $dtstartRow instanceof Pc) {
                     if (!$dtstartRow->hasParamValue(IcalInterface::TZID)) {
@@ -877,7 +877,7 @@ class CalendarImport extends \Backend
                             DateTimeZoneFactory::factory($tz[1])
                         );
                     } else {
-                        $dtStartTz = $dtstartRow->getParams(IcalInterface::TZID);
+                        $timezone = $dtstartRow->getParams(IcalInterface::TZID);
                     }
                     $arrFields['startDate'] = $dtstart->getTimestamp();
                     if (!$dtstartRow->hasParamValue(IcalInterface::DATE)) {
@@ -930,7 +930,7 @@ class CalendarImport extends \Backend
 
                     $repeatEach['value'] = $rrule['INTERVAL'] ?? 1;
                     $arrFields['repeatEach'] = serialize($repeatEach);
-                    $arrFields['repeatEnd'] = $this->getRepeatEnd($arrFields, $rrule, $repeatEach, $dtStartTz);
+                    $arrFields['repeatEnd'] = $this->getRepeatEnd($arrFields, $rrule, $repeatEach, $timezone);
 
                     if (isset($rrule['WKST']) && is_array($rrule['WKST'])) {
                         $weekdays = ['MO' => 1, 'TU' => 2, 'WE' => 3, 'TH' => 4, 'FR' => 5, 'SA' => 6, 'SU' => 0];
@@ -1493,17 +1493,17 @@ class CalendarImport extends \Backend
      * @param array $arrFields
      * @param array $rrule
      * @param array $repeatEach
-     * @param string $dtStartTz
+     * @param string $timezone
      * @return int
      * @throws Exception
      */
-    private function getRepeatEnd($arrFields, $rrule, $repeatEach, $dtStartTz)
+    private function getRepeatEnd($arrFields, $rrule, $repeatEach, $timezone)
     {
         if (($until = $rrule[IcalInterface::UNTIL] ?? null) instanceof \DateTime) {
-            // convert UNTIL date to DTSTART timezone
+            // convert UNTIL date to current timezone
             $until = new \DateTime(
                 $until->format(DateTimeFactory::$YmdHis),
-                DateTimeZoneFactory::factory($dtStartTz)
+                DateTimeZoneFactory::factory($timezone)
             );
 
             return $until->getTimestamp();

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -930,7 +930,7 @@ class CalendarImport extends \Backend
 
                     $repeatEach['value'] = $rrule['INTERVAL'] ?? 1;
                     $arrFields['repeatEach'] = serialize($repeatEach);
-                    $arrFields['repeatEnd'] = $this->getRepeatEnd($arrFields, $rrule, $repeatEach, $timezone);
+                    $arrFields['repeatEnd'] = $this->getRepeatEnd($arrFields, $rrule, $repeatEach, $timezone, $timeshift);
 
                     if (isset($rrule['WKST']) && is_array($rrule['WKST'])) {
                         $weekdays = ['MO' => 1, 'TU' => 2, 'WE' => 3, 'TH' => 4, 'FR' => 5, 'SA' => 6, 'SU' => 0];
@@ -1494,10 +1494,11 @@ class CalendarImport extends \Backend
      * @param array $rrule
      * @param array $repeatEach
      * @param string $timezone
+     * @param int $timeshift
      * @return int
      * @throws Exception
      */
-    private function getRepeatEnd($arrFields, $rrule, $repeatEach, $timezone)
+    private function getRepeatEnd($arrFields, $rrule, $repeatEach, $timezone, $timeshift = 0)
     {
         if (($until = $rrule[IcalInterface::UNTIL] ?? null) instanceof \DateTime) {
             // convert UNTIL date to current timezone
@@ -1506,7 +1507,11 @@ class CalendarImport extends \Backend
                 DateTimeZoneFactory::factory($timezone)
             );
 
-            return $until->getTimestamp();
+            $timestamp = $until->getTimestamp();
+            if ($timeshift != 0) {
+                $timestamp += $timeshift * 3600;
+            }
+            return $timestamp;
         }
 
         if ((int)$arrFields['recurrences'] === 0) {

--- a/src/Resources/contao/classes/ContentICal.php
+++ b/src/Resources/contao/classes/ContentICal.php
@@ -109,12 +109,12 @@ class ContentICal extends ContentElement
         }
 
         $this->ical = new Vcalendar();
-        $this->ical->setProperty('method', 'PUBLISH');
-        $this->ical->setProperty("x-wr-calname",
+        $this->ical->setMethod(Vcalendar::PUBLISH);
+        $this->ical->setXprop(Vcalendar::X_WR_CALNAME,
             (strlen(\Input::get('title'))) ? \Input::get('title') : $this->strTitle);
-        $this->ical->setProperty("X-WR-CALDESC",
+        $this->ical->setXprop(Vcalendar::X_WR_CALDESC,
             (strlen(\Input::get('title'))) ? \Input::get('title') : $this->strTitle);
-        $this->ical->setProperty("X-WR-TIMEZONE", $GLOBALS['TL_CONFIG']['timeZone']);
+        $this->ical->setXprop(Vcalendar::X_WR_TIMEZONE, $GLOBALS['TL_CONFIG']['timeZone']);
         $time = time();
 
         foreach ($arrCalendars as $id) {

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -26,7 +26,9 @@ $GLOBALS['TL_CRON']['daily'][] = array('CalendarExport', 'generateSubscriptions'
 /**
  * Add 'ical' to the URL keywords to prevent problems with URL manipulating modules like folderurl
  */
-$GLOBALS['TL_CONFIG']['urlKeywords'] .= (strlen(trim($GLOBALS['TL_CONFIG']['urlKeywords'])) ? ',' : '') . 'ical';
+if (isset($GLOBALS['TL_CONFIG']['urlKeywords'])) {
+    $GLOBALS['TL_CONFIG']['urlKeywords'] .= (strlen(trim($GLOBALS['TL_CONFIG']['urlKeywords'])) ? ',' : '') . 'ical';
+}
 
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('CalendarExport', 'removeOldSubscriptions');
 $GLOBALS['TL_HOOKS']['getAllEvents'][] = array('CalendarImport', 'getAllEvents');


### PR DESCRIPTION
This PR fixes the compatibility with Kigkonsult Icalcreator 2.39+

- Fix config of Vcalendar with constants
- Fix deprecated iCal property setter
- Fix deprecated iCal property getter
- Fix deprecated iCal file parsing

While debuggin I also fixed some minor php 8 issues
- Fix undefined array key urlKeywords
- Fix undefined constant `ENCODE_AMPERSANDS`
- Fix undefined array key for found events
