### PR TITLE
Feature location of the core

### DIFF
--- a/src/Resources/contao/classes/CalendarExport.php
+++ b/src/Resources/contao/classes/CalendarExport.php
@@ -185,11 +185,11 @@ class CalendarExport extends \Backend
                 $vevent->setDescription(html_entity_decode(strip_tags(preg_replace('/<br \\/>/', "\n",
                     $this->replaceInsertTags($objEvents->teaser))), ENT_QUOTES, 'UTF-8'));
 
-                if ($objEvents->cep_location) {
-                    $vevent->setDescription(trim(html_entity_decode($objEvents->cep_location, ENT_QUOTES, 'UTF-8')));
+                if (!empty($objEvents->location)) {
+                    $vevent->setLocation(trim(html_entity_decode($objEvents->location, ENT_QUOTES, 'UTF-8')));
                 }
 
-                if ($objEvents->cep_participants) {
+                if (!empty($objEvents->cep_participants)) {
                     $attendees = preg_split("/,/", $objEvents->cep_participants);
                     if (count($attendees)) {
                         foreach ($attendees as $attendee) {
@@ -203,8 +203,8 @@ class CalendarExport extends \Backend
                     }
                 }
 
-                if ($objEvents->cep_contact) {
-                    $contact = trim($objEvents->cep_contact);
+                if (!empty($objEvents->location_contact)) {
+                    $contact = trim($objEvents->location_contact);
                     $vevent->setContact($contact);
                 }
 

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -221,23 +221,14 @@ class CalendarImport extends \Backend
             array('teaser', $GLOBALS['TL_LANG']['tl_calendar_events']['teaser'][0])
         );
 
-        if (in_array('location', $fieldnames)) {
-            array_push(
-                $calfields,
-                array('location', $GLOBALS['TL_LANG']['tl_calendar_events']['location'][0])
-            );
+        if (in_array('location', $fieldnames, true)) {
+            $calfields[] = array('location', $GLOBALS['TL_LANG']['tl_calendar_events']['location'][0]);
         }
-        if (in_array('cep_participants', $fieldnames)) {
-            array_push(
-                $calfields,
-                array('cep_participants', $GLOBALS['TL_LANG']['tl_calendar_events']['cep_participants'][0])
-            );
+        if (in_array('cep_participants', $fieldnames, true)) {
+            $calfields[] = array('cep_participants', $GLOBALS['TL_LANG']['tl_calendar_events']['cep_participants'][0]);
         }
-        if (in_array('location_contact', $fieldnames)) {
-            array_push(
-                $calfields,
-                array('location_contact', $GLOBALS['TL_LANG']['tl_calendar_events']['location_contact'][0])
-            );
+        if (in_array('location_contact', $fieldnames, true)) {
+            $calfields[] = array('location_contact', $GLOBALS['TL_LANG']['tl_calendar_events']['location_contact'][0]);
         }
 
         $dateFormat = \Input::post('dateFormat');
@@ -828,31 +819,26 @@ class CalendarImport extends \Backend
                 }
 
                 // calendar_events_plus fields
-                if (array_key_exists('location', $arrFields)) {
-                    if (strlen($location)) {
-                        $arrFields['location'] =
-                            preg_replace("/(\\\\r)|(\\\\n)/ims", "\n", $location);
-                    }
-                } else {
-                    if (strlen($location)) {
-                        array_push($eventcontent,
-                            '<p><strong>' . $GLOBALS['TL_LANG']['MSC']['location'] . ':</strong> ' . preg_replace("/(\\\\r)|(\\\\n)/ims",
-                                "<br />", $location) . "</p>");
+                if (!empty($location)) {
+                    if (array_key_exists('location', $arrFields)) {
+                        $location = preg_replace("/(\\\\r)|(\\\\n)/im", "\n", $location);
+                        $arrFields['location'] = $location;
+                    } else {
+                        $location = preg_replace("/(\\\\r)|(\\\\n)/im", "<br />", $location);
+                        $eventcontent[] = '<p><strong>'.$GLOBALS['TL_LANG']['MSC']['location'].':</strong> '.$location."</p>";
                     }
                 }
 
-                if (array_key_exists('cep_participants', $arrFields)) {
-                    if (is_array($vevent->attendee)) {
-                        $attendees = array();
-                        foreach ($vevent->attendee as $attendee) {
-                            if (strlen($attendee['params']['CN'])) {
-                                array_push($attendees, $attendee['params']['CN']);
-                            }
+                if (array_key_exists('cep_participants', $arrFields) && is_array($vevent->attendee)) {
+                    $attendees = array();
+                    foreach ($vevent->attendee as $attendee) {
+                        if (!empty($attendee['params']['CN'])) {
+                            $attendees[] = $attendee['params']['CN'];
                         }
+                    }
 
-                        if (count($attendees)) {
-                            $arrFields['cep_participants'] = join(',', $attendees);
-                        }
+                    if (count($attendees)) {
+                        $arrFields['cep_participants'] = implode(',', $attendees);
                     }
                 }
 
@@ -861,12 +847,12 @@ class CalendarImport extends \Backend
                     if (is_array($contact)) {
                         $contacts = array();
                         foreach ($contact as $data) {
-                            if (strlen($data['value'])) {
-                                array_push($contacts, $data['value']);
+                            if (!empty($data['value'])) {
+                                $contacts[] = $data['value'];
                             }
                         }
                         if (count($contacts)) {
-                            $arrFields['location_contact'] = join(',', $contacts);
+                            $arrFields['location_contact'] = implode(',', $contacts);
                         }
                     }
                 }

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -221,11 +221,22 @@ class CalendarImport extends \Backend
             array('teaser', $GLOBALS['TL_LANG']['tl_calendar_events']['teaser'][0])
         );
 
-        if (in_array('cep_location', $fieldnames)) {
-            array_push($calfields,
-                array('cep_location', $GLOBALS['TL_LANG']['tl_calendar_events']['cep_location'][0]),
-                array('cep_participants', $GLOBALS['TL_LANG']['tl_calendar_events']['cep_participants'][0]),
-                array('cep_contact', $GLOBALS['TL_LANG']['tl_calendar_events']['cep_contact'][0])
+        if (in_array('location', $fieldnames)) {
+            array_push(
+                $calfields,
+                array('location', $GLOBALS['TL_LANG']['tl_calendar_events']['location'][0])
+            );
+        }
+        if (in_array('cep_participants', $fieldnames)) {
+            array_push(
+                $calfields,
+                array('cep_participants', $GLOBALS['TL_LANG']['tl_calendar_events']['cep_participants'][0])
+            );
+        }
+        if (in_array('location_contact', $fieldnames)) {
+            array_push(
+                $calfields,
+                array('location_contact', $GLOBALS['TL_LANG']['tl_calendar_events']['location_contact'][0])
             );
         }
 
@@ -817,9 +828,9 @@ class CalendarImport extends \Backend
                 }
 
                 // calendar_events_plus fields
-                if (array_key_exists('cep_location', $arrFields)) {
+                if (array_key_exists('location', $arrFields)) {
                     if (strlen($location)) {
-                        $arrFields['cep_location'] =
+                        $arrFields['location'] =
                             preg_replace("/(\\\\r)|(\\\\n)/ims", "\n", $location);
                     }
                 } else {
@@ -845,8 +856,8 @@ class CalendarImport extends \Backend
                     }
                 }
 
-                if (array_key_exists('cep_contact', $arrFields)) {
-                    $contact = $vevent->contact;
+                if (array_key_exists('location_contact', $arrFields)) {
+                    $contact = $vevent->getContact();
                     if (is_array($contact)) {
                         $contacts = array();
                         foreach ($contact as $data) {
@@ -855,7 +866,7 @@ class CalendarImport extends \Backend
                             }
                         }
                         if (count($contacts)) {
-                            $arrFields['cep_contact'] = join(',', $contacts);
+                            $arrFields['location_contact'] = join(',', $contacts);
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds support for the core `location` field instead of the deprecated `cep_location` from the extension `calendar_plus`.
It even supports `location_contact` instead of 'cep_contact' from `kmielke/calendar-extended-bundle`.
I couldn't find a valid equivalent for `cep_participants`.

Of course we could discuss if it makes sense to support the core fields instead of the `calendar_plus` fields. But the extension `calendar_plus` is deprecated (https://contao.org/en/extension-list/view/calendar_events_plus.html - a copy can be found here: https://gausi.de/calendar_edit_plus.html)