### PR TITLE
Keep the existing event id by matching uuid while ical import

### DIFF
--- a/contao/dca/tl_calendar_events.php
+++ b/contao/dca/tl_calendar_events.php
@@ -26,3 +26,9 @@ $GLOBALS['TL_DCA']['tl_calendar_events']['fields']['icssource'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_content']['source'],
     'eval' => ['fieldType' => 'radio', 'files' => true, 'filesOnly' => true, 'extensions' => 'ics,csv'],
 ];
+
+$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['ical_uuid'] = [
+    'inputType' => 'text',
+    'eval' => ['maxlength' => 255, 'tl_class' => 'long'],
+    'sql' => "varchar(255) NOT NULL default ''",
+];

--- a/src/Backend/Automator.php
+++ b/src/Backend/Automator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/CgoitContaoCalendarIcalBundle.php
+++ b/src/CgoitContaoCalendarIcalBundle.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Cron/GenerateSubscriptionsCron.php
+++ b/src/Cron/GenerateSubscriptionsCron.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Cron/ImportCalendarsFromIcsCron.php
+++ b/src/Cron/ImportCalendarsFromIcsCron.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/DependencyInjection/CgoitContaoCalendarIcalExtension.php
+++ b/src/DependencyInjection/CgoitContaoCalendarIcalExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarDeleteListener.php
+++ b/src/EventListener/DataContainer/CalendarDeleteListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarEventsSubmitListener.php
+++ b/src/EventListener/DataContainer/CalendarEventsSubmitListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarHeaderCallback.php
+++ b/src/EventListener/DataContainer/CalendarHeaderCallback.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarIcalAliasSaveListener.php
+++ b/src/EventListener/DataContainer/CalendarIcalAliasSaveListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarSubmitListener.php
+++ b/src/EventListener/DataContainer/CalendarSubmitListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/ContentCalendarOptionsListener.php
+++ b/src/EventListener/DataContainer/ContentCalendarOptionsListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/GetAllEventsListener.php
+++ b/src/EventListener/GetAllEventsListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventSubscriber/AddBackendAssetsSubscriber.php
+++ b/src/EventSubscriber/AddBackendAssetsSubscriber.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -67,4 +67,25 @@ class AbstractImport extends Backend
 
         return $objEvent->save();
     }
+
+    protected function deleteEvents($events): void
+    {
+        if (empty($events)) {
+            return;
+        }
+
+        foreach ($events as $event) {
+            $columns = ['ptable=? AND pid=?'];
+            $values = ['tl_calendar_events', $event->id];
+            $content = ContentModel::findBy($columns, $values);
+
+            if ($content) {
+                while ($content->next()) {
+                    $content->delete();
+                }
+            }
+
+            $event->delete();
+        }
+    }
 }

--- a/src/Import/Csv/Csv.php
+++ b/src/Import/Csv/Csv.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */
@@ -78,10 +78,8 @@ class Csv
         return $string;
     }
 
-    // checks if a string ends with an unescaped quote
-    // 'string"' => true
-    // 'string""' => false
-    // 'string"""' => true
+    // checks if a string ends with an unescaped quote 'string"' => true 'string""'
+    // => false 'string"""' => true
     public static function _hasEndQuote(string $token): bool
     {
         $len = \strlen($token);

--- a/src/Import/Csv/CsvReader.php
+++ b/src/Import/Csv/CsvReader.php
@@ -47,8 +47,8 @@ class CsvReader implements \Iterator
         $this->close();
     }
 
-    // You should not have to call it unless you need to
-    // explicitly free the file descriptor
+    // You should not have to call it unless you need to explicitly free the
+    // file descriptor
     public function close(): void
     {
         if ($this->fileHandle) {

--- a/src/Import/CsvImport.php
+++ b/src/Import/CsvImport.php
@@ -10,7 +10,6 @@ use Contao\BackendTemplate;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\Config;
-use Contao\ContentModel;
 use Contao\CoreBundle\Slug\Slug;
 use Contao\Date;
 use Contao\Environment;
@@ -154,19 +153,7 @@ class CsvImport extends AbstractImport
 
         if (!empty($importSettings['csv_deletecalendar']) && !empty($importSettings['csv_pid'])) {
             $objEvents = CalendarEventsModel::findByPid($importSettings['csv_pid']);
-            if (!empty($objEvents)) {
-                foreach ($objEvents as $event) {
-                    $arrColumns = ['ptable=? AND pid=?'];
-                    $arrValues = ['tl_calendar_events', $event->id];
-                    $content = ContentModel::findBy($arrColumns, $arrValues);
-                    if ($content) {
-                        while ($content->next()) {
-                            $content->delete();
-                        }
-                    }
-                    $event->delete();
-                }
-            }
+            $this->deleteEvents($objEvents);
         }
 
         $done = false;

--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -8,7 +8,6 @@ use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\Config;
-use Contao\ContentModel;
 use Contao\CoreBundle\Slug\Slug;
 use Contao\Date;
 use Contao\File;
@@ -92,23 +91,14 @@ class IcsImport extends AbstractImport
 
         $foundevents = [];
 
-        if ($deleteCalendar && !empty($objCalendar->id)) {
-            $arrEvents = CalendarEventsModel::findByPid($objCalendar->id);
-            if (!empty($arrEvents)) {
-                foreach ($arrEvents as $event) {
-                    $arrColumns = ['ptable=? AND pid=?'];
-                    $arrValues = ['tl_calendar_events', $event->id];
-                    $content = ContentModel::findBy($arrColumns, $arrValues);
+        $arrEvents = !empty($objCalendar->id) ? CalendarEventsModel::findByPid($objCalendar->id) : [];
+        $eventsDictionary = [];
 
-                    if ($content) {
-                        while ($content->next()) {
-                            $content->delete();
-                        }
-                    }
-
-                    $event->delete();
-                }
+        foreach ($arrEvents as $event) {
+            if (empty($event->ical_uuid)) {
+                $event->ical_uuid = uniqid('', true);
             }
+            $eventsDictionary[$event->ical_uuid] = $event;
         }
 
         $eventArray = $cal->selectComponents((int) date('Y', (int) $startDate->tstamp), (int) date('m', (int) $startDate->tstamp),
@@ -118,7 +108,15 @@ class IcsImport extends AbstractImport
         if (\is_array($eventArray)) {
             /** @var Vevent $vevent */
             foreach ($eventArray as $vevent) {
-                $objEvent = new CalendarEventsModel();
+                // Use the existing event with matching uuid
+                $uid = $vevent->getUid();
+                if (isset($eventsDictionary[$uid])) {
+                    $objEvent = $eventsDictionary[$uid];
+                    unset($eventsDictionary[$uid]);
+                } else {
+                    $objEvent = new CalendarEventsModel();
+                    $objEvent->ical_uuid = $uid;
+                }
                 $objEvent->tstamp = time();
                 $objEvent->pid = $objCalendar->id;
                 $objEvent->published = true;
@@ -147,7 +145,6 @@ class IcsImport extends AbstractImport
                 }
                 $description = $vevent->getDescription() ?: '';
                 $location = trim($vevent->getLocation() ?: '');
-                $uid = $vevent->getUid();
 
                 $title = $summary;
                 if (!empty($patternEventTitle) && !empty($replacementEventTitle)) {
@@ -271,7 +268,7 @@ class IcsImport extends AbstractImport
 
                     if (\in_array('repeatWeekday', $fieldNames, true) && isset($rrule['WKST']) && \is_array($rrule['WKST'])) {
                         $weekdays = ['MO' => 1, 'TU' => 2, 'WE' => 3, 'TH' => 4, 'FR' => 5, 'SA' => 6, 'SU' => 0];
-                        $mapWeekdays = static fn (string $value): ?int => $weekdays[$value] ?? null;
+                        $mapWeekdays = static fn (string $value): int|null => $weekdays[$value] ?? null;
                         $objEvent->repeatWeekday = serialize(array_map($mapWeekdays, $rrule['WKST']));
                     }
                 }
@@ -295,6 +292,10 @@ class IcsImport extends AbstractImport
                     $this->generateAlias($objEvent);
                 }
             }
+        }
+
+        if ($deleteCalendar) {
+            $this->deleteEvents($eventsDictionary);
         }
     }
 

--- a/src/Util/TimezoneUtil.php
+++ b/src/Util/TimezoneUtil.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Util/TimezoneUtilAwareInterface.php
+++ b/src/Util/TimezoneUtilAwareInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Widgets/WidgetTrait.php
+++ b/src/Widgets/WidgetTrait.php
@@ -46,8 +46,7 @@ trait WidgetTrait
         $widget->value = $value;
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['importDeleteCalendar'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importDeleteCalendar'][1];
         }
 
@@ -81,8 +80,7 @@ trait WidgetTrait
         ];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['correctTimezone'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['correctTimezone'][1];
         }
 
@@ -113,8 +111,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['timezone'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['timezone'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['timezone'][1];
         }
 
@@ -163,8 +160,7 @@ trait WidgetTrait
                 (string) $GLOBALS['TL_LANG']['tl_calendar_events']['importFilterEventTitle'][1],
             )
         ) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importFilterEventTitle'][1];
         }
 
@@ -200,8 +196,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['icssource'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['icssource'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['icssource'][1];
         }
 
@@ -236,8 +231,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['importStartDate'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['importStartDate'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importStartDate'][1];
         }
 
@@ -271,8 +265,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['importEndDate'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['importEndDate'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importEndDate'][1];
         }
 
@@ -305,8 +298,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['importTimeShift'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen((string) $GLOBALS['TL_LANG']['tl_calendar_events']['importTimeShift'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importTimeShift'][1];
         }
 
@@ -336,8 +328,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['importDateFormat'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && !empty((string) $GLOBALS['TL_LANG']['tl_calendar_events']['importDateFormat'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importDateFormat'][1];
         }
 
@@ -367,8 +358,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['importTimeFormat'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && !empty((string) $GLOBALS['TL_LANG']['tl_calendar_events']['importTimeFormat'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['importTimeFormat'][1];
         }
 
@@ -395,8 +385,7 @@ trait WidgetTrait
         $widget->label = $GLOBALS['TL_LANG']['tl_calendar_events']['encoding'][0];
 
         if ($GLOBALS['TL_CONFIG']['showHelp'] && !empty((string) $GLOBALS['TL_LANG']['tl_calendar_events']['encoding'][1])) {
-            // TODO prüfen, ob der Text hin muss
-            // @phpstan-ignore-next-line
+            // TODO prüfen, ob der Text hin muss @phpstan-ignore-next-line
             $widget->help = $GLOBALS['TL_LANG']['tl_calendar_events']['encoding'][1];
         }
 

--- a/tests/CgoitContaoCalendarIcalBundleTest.php
+++ b/tests/CgoitContaoCalendarIcalBundleTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-php8-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2024, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */


### PR DESCRIPTION
This PR solves the issue that the event id will be changed or increased on every iCal import.
Therefore all existing events are saved in a dictionary and after the import the events which where not in the iCal file are deleted instead of full deletion before the import.

EDIT: the CS commit was necessary because of build errors