### PR TITLE
Hotfix empty calendar and existing content

### DIFF
--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -33,7 +33,9 @@ class AbstractImport extends Backend
         $step = 128;
 
         foreach ($eventcontent as $content) {
-            $cm = new ContentModel();
+            $columns = ['ptable=? AND pid=? AND sorting=?'];
+            $values = ['tl_calendar_events', $objEvent->id, $step];
+            $cm = ContentModel::findBy($columns, $values)?->first() ?? new ContentModel();
             $cm->tstamp = time();
             $cm->pid = $objEvent->id;
             $cm->ptable = 'tl_calendar_events';

--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -91,7 +91,7 @@ class IcsImport extends AbstractImport
 
         $foundevents = [];
 
-        $arrEvents = !empty($objCalendar->id) ? CalendarEventsModel::findByPid($objCalendar->id) : [];
+        $arrEvents = !empty($objCalendar->id) ? CalendarEventsModel::findByPid($objCalendar->id) ?? [] : [];
         $eventsDictionary = [];
 
         foreach ($arrEvents as $event) {

--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -137,7 +137,7 @@ class IcsImport extends AbstractImport
                 $dtend = $vevent->getDtend(true);
 
                 $rrule = $vevent->getRrule();
-                $summary = $vevent->getSummary() ?? '';
+                $summary = $vevent->getSummary() ?: '---';
                 if (!empty($filterEventTitle) && !str_contains(mb_strtolower($summary), mb_strtolower($filterEventTitle))) {
                     continue;
                 }


### PR DESCRIPTION
This PR will fix some issues while importing icals since #28 

- fix the import for empty event list used for the dictionary introduced in #28 
- fix the import of empty event title
- fix use existing content elements (here we could discuss that if you remove the location in the ical it stay as content element, because it won't be removed / overwriten. but this really a edge case and better then a new content element on every import after keeping them with #28