### PR TITLE
Fix missing framework initialization on cron

### DIFF
--- a/src/Cron/GenerateSubscriptionsCron.php
+++ b/src/Cron/GenerateSubscriptionsCron.php
@@ -22,7 +22,7 @@ class GenerateSubscriptionsCron
 {
     public function __construct(
         private readonly ExportController $calendarExport,
-        private readonly ContaoFramework $contaoFramework
+        private readonly ContaoFramework $contaoFramework,
     ) {
     }
 
@@ -32,7 +32,7 @@ class GenerateSubscriptionsCron
 
         $arrCalendar = CalendarModel::findBy(['make_ical=?'], [1]);
 
-        if (!$arrCalendar) {
+        if (empty($arrCalendar)) {
             return;
         }
 

--- a/src/Cron/GenerateSubscriptionsCron.php
+++ b/src/Cron/GenerateSubscriptionsCron.php
@@ -15,17 +15,26 @@ namespace Cgoit\ContaoCalendarIcalBundle\Cron;
 use Cgoit\ContaoCalendarIcalBundle\Backend\ExportController;
 use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
+use Contao\CoreBundle\Framework\ContaoFramework;
 
 #[AsCronJob('daily')]
 class GenerateSubscriptionsCron
 {
-    public function __construct(private readonly ExportController $calendarExport)
-    {
+    public function __construct(
+        private readonly ExportController $calendarExport,
+        private readonly ContaoFramework $contaoFramework
+    ) {
     }
 
     public function __invoke(): void
     {
+        $this->contaoFramework->initialize();
+
         $arrCalendar = CalendarModel::findBy(['make_ical=?'], [1]);
+
+        if (!$arrCalendar) {
+            return;
+        }
 
         foreach ($arrCalendar as $objCalendar) {
             $this->calendarExport->generateSubscriptions($objCalendar);

--- a/src/Cron/ImportCalendarsFromIcsCron.php
+++ b/src/Cron/ImportCalendarsFromIcsCron.php
@@ -15,17 +15,21 @@ namespace Cgoit\ContaoCalendarIcalBundle\Cron;
 use Cgoit\ContaoCalendarIcalBundle\Import\IcsImport;
 use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
+use Contao\CoreBundle\Framework\ContaoFramework;
 
 #[AsCronJob('daily')]
 class ImportCalendarsFromIcsCron
 {
     public function __construct(
         private readonly IcsImport $icsImport,
+        private readonly ContaoFramework $contaoFramework,
     ) {
     }
 
     public function __invoke(): void
     {
+        $this->contaoFramework->initialize();
+
         $arrCalendars = CalendarModel::findBy(['ical_source != ?'], ['']);
 
         if (!empty($arrCalendars)) {

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -85,7 +85,7 @@ class AbstractImport extends Backend
         // Generate the alias if there is none
         $objEvent->alias = $this->slug->generate(
             $objEvent->title,
-            CalendarModel::findByPk($objEvent->pid)->jumpTo,
+            CalendarModel::findById($objEvent->pid)->jumpTo,
             $aliasExists,
         );
 

--- a/src/Import/Csv/Csv.php
+++ b/src/Import/Csv/Csv.php
@@ -16,7 +16,8 @@ class Csv
 {
     /**
      * take a CSV line (utf-8 encoded) and returns an array
-     * 'string1,string2,"string3","the ""string4"""' => array('string1', 'string2', 'string3', 'the "string4"').
+     * 'string1,string2,"string3","the ""string4"""' => array('string1', 'string2',
+     * 'string3', 'the "string4"').
      *
      * @return array<string>
      */


### PR DESCRIPTION
This PR fix the missing contao framework initialization in the cronjob subscribers. 

Problem description:
If the cronjobs are executed standalone or the first beeing execute an exception is thrown as the contao framework is not initialized. But it is needed to be initialized when using Contao Models.