### PR TITLE
Fix csv-import in Contao 5.5

### DIFF
--- a/contao/templates/be_import_calendar.html5
+++ b/contao/templates/be_import_calendar.html5
@@ -6,7 +6,7 @@
 <h2 class="sub_headline"><?= $this->headline; ?></h2>
 <?= $this->message; ?>
 
-<form action="<?= $this->request; ?>" id="tl_import_calendar" class="tl_form" method="post" enctype="multipart/form-data">
+<form action="<?= $this->request; ?>" id="tl_import_calendar" class="tl_form" method="post"  data-turbo="false" enctype="multipart/form-data">
     <div class="tl_formbody_edit">
         <input type="hidden" name="FORM_SUBMIT" value="tl_import_calendar" />
         <input type="hidden" name="REQUEST_TOKEN" value="<?= $this->request_token ?>" />


### PR DESCRIPTION
Dieser PR behebt ein Problem mit stimulus/turbo: Ein csv-import ist nicht möglich, die Datei wird zwar hochgeladen, kann aber nicht weiter verarbeitet werden.