### PR TITLE
Add before import event

### DIFF
--- a/src/Event/BeforeImportItemEvent.php
+++ b/src/Event/BeforeImportItemEvent.php
@@ -20,6 +20,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 class BeforeImportItemEvent extends Event
 {
     public bool $skip = false;
+
     public function __construct(
         public readonly CalendarEventsModel $calendarEventModel,
         public readonly Vevent $vevent,

--- a/src/Event/BeforeImportItemEvent.php
+++ b/src/Event/BeforeImportItemEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2025, cgoIT
+ * @author     cgoIT <https://cgo-it.de>
+ * @license    LGPL-3.0-or-later
+ */
+
+namespace Cgoit\ContaoCalendarIcalBundle\Event;
+
+use Contao\CalendarEventsModel;
+use Contao\CalendarModel;
+use Kigkonsult\Icalcreator\Vevent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BeforeImportItemEvent extends Event
+{
+    public bool $skip = false;
+    public function __construct(
+        public readonly CalendarEventsModel $calendarEventModel,
+        public readonly Vevent $vevent,
+        public readonly CalendarModel $calendarModel,
+    ) {
+    }
+}

--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Cgoit\ContaoCalendarIcalBundle\Import;
 
-use Cgoit\ContaoCalendarIcalBundle\Event\AfterImportItemEvent;
+use Cgoit\ContaoCalendarIcalBundle\Event\BeforeImportItemEvent;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
@@ -143,6 +143,17 @@ class IcsImport extends AbstractImport
                     $objEvent = new CalendarEventsModel();
                     $objEvent->ical_uuid = $uid;
                 }
+
+                $beforeEvent = $this->eventDispatcher->dispatch(new BeforeImportItemEvent(
+                    $objEvent,
+                    $vevent,
+                    $objCalendar,
+                ));
+
+                if ($beforeEvent->skip) {
+                    continue;
+                }
+
                 $objEvent->tstamp = time();
                 $objEvent->pid = $objCalendar->id;
                 $objEvent->published = true;
@@ -372,7 +383,7 @@ class IcsImport extends AbstractImport
 
                     $this->generateAlias($objEvent);
 
-                    $this->eventDispatcher->dispatch(new AfterImportItemEvent(
+                    $this->eventDispatcher->dispatch(new BeforeImportItemEvent(
                         $objEvent,
                         $vevent,
                         $objCalendar,

--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cgoit\ContaoCalendarIcalBundle\Import;
 
+use Cgoit\ContaoCalendarIcalBundle\Event\AfterImportItemEvent;
 use Cgoit\ContaoCalendarIcalBundle\Event\BeforeImportItemEvent;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
@@ -383,7 +384,7 @@ class IcsImport extends AbstractImport
 
                     $this->generateAlias($objEvent);
 
-                    $this->eventDispatcher->dispatch(new BeforeImportItemEvent(
+                    $this->eventDispatcher->dispatch(new AfterImportItemEvent(
                         $objEvent,
                         $vevent,
                         $objCalendar,


### PR DESCRIPTION
This PR is a follow up to #79 and add an event before import an event with the ability to skip the import.

My use case is to skip importing events I have edited in contao to don't get my changes overwritten.