### PR TITLE
Fix error on deleting Calendar in Version 4.13

### DIFF
--- a/src/EventListener/DataContainer/CalendarDeleteListener.php
+++ b/src/EventListener/DataContainer/CalendarDeleteListener.php
@@ -36,8 +36,7 @@ class CalendarDeleteListener
 
         $activeRecord = null;
         $contaoVersion = ContaoCoreBundle::getVersion();
-        if(version_compare($contaoVersion, '5.0.0') >= 0)
-        {
+        if (version_compare($contaoVersion, '5.0.0') >= 0) {
             $activeRecord = (object) $dc->getCurrentRecord();
         } else {
             $activeRecord = (object) $dc->activeRecord;


### PR DESCRIPTION
Hi,

In Contao 4 there is no getCurrentRecord method on the DataContainer and it throws an error.
Please merge to stay backwards-compatible.

Best wishes,
SyZn