### PR TITLE
Add empty check for arrRepeat and add int typecasts for date()

### DIFF
--- a/src/Export/IcsExport.php
+++ b/src/Export/IcsExport.php
@@ -155,33 +155,33 @@ class IcsExport extends Backend
             $vevent = new Vevent();
 
             if (!empty($objEvent->addTime)) {
-                $vevent->setDtstart(date(DateTimeFactory::$YmdTHis, $objEvent->startTime), [IcalInterface::VALUE => IcalInterface::DATE_TIME]);
+                $vevent->setDtstart(date(DateTimeFactory::$YmdTHis, (int) $objEvent->startTime), [IcalInterface::VALUE => IcalInterface::DATE_TIME]);
                 if (!empty($objEvent->endTime)) {
                     if ((int) $objEvent->startTime < (int) $objEvent->endTime) {
-                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, $objEvent->endTime),
+                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, (int) $objEvent->endTime),
                             [IcalInterface::VALUE => IcalInterface::DATE_TIME]);
                     } else {
-                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, $objEvent->startTime + 60 * 60),
+                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, ((int) $objEvent->startTime) + 60 * 60),
                             [IcalInterface::VALUE => IcalInterface::DATE_TIME]);
                     }
                 } else {
-                    $vevent->setDtend(date(DateTimeFactory::$YmdTHis, $objEvent->startTime + 60 * 60),
+                    $vevent->setDtend(date(DateTimeFactory::$YmdTHis, ((int) $objEvent->startTime) + 60 * 60),
                         [IcalInterface::VALUE => IcalInterface::DATE_TIME]);
                 }
             } else {
-                $vevent->setDtstart(date(DateTimeFactory::$Ymd, $startDate), [IcalInterface::VALUE => IcalInterface::DATE]);
+                $vevent->setDtstart(date(DateTimeFactory::$Ymd, (int) $startDate), [IcalInterface::VALUE => IcalInterface::DATE]);
                 if (!empty($endDate)) {
                     if ((int) $startDate < (int) $objEvent->endTime) {
                         // add one second because in ICS the end date is exclusive, in Contao its inclusive
                         // and the time part is always 235959.
-                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, $objEvent->endTime + 1),
+                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, ((int) $objEvent->endTime) + 1),
                             [IcalInterface::VALUE => IcalInterface::DATE]);
                     } else {
-                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, $startDate + 24 * 60 * 60),
+                        $vevent->setDtend(date(DateTimeFactory::$YmdTHis, ((int) $startDate) + 24 * 60 * 60),
                             [IcalInterface::VALUE => IcalInterface::DATE]);
                     }
                 } else {
-                    $vevent->setDtend(date(DateTimeFactory::$Ymd, $startDate + 24 * 60 * 60),
+                    $vevent->setDtend(date(DateTimeFactory::$Ymd, ((int) $startDate) + 24 * 60 * 60),
                         [IcalInterface::VALUE => IcalInterface::DATE]);
                 }
             }
@@ -225,6 +225,7 @@ class IcsExport extends Backend
 
             if ($objEvent->recurring) {
                 $arrRepeat = StringUtil::deserialize($objEvent->repeatEach, true);
+
                 if (!empty($arrRepeat)) {
                     $arg = $arrRepeat['value'];
 


### PR DESCRIPTION
Hello,

I just had issues concerning an empty `$arrRepeat`. I know this shouldn't be the case, but in contao's dca there are certain real world situations where this can happen.

Also added some int typecasts causing me warnings in dev environments because (at least in contao 4.13), startTime and startDate might be strings and date expects int (php 8.3).

Thanks for merging :-)

Bye Defcon0