### PR TITLE
fix: recurrence count calculation

### DIFF
--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -360,6 +360,7 @@ class IcsImport extends AbstractImport
                         if (\array_key_exists('COUNT', $rrule)) {
                             $recurrences = ((int) $rrule['COUNT']) - 1;
                         } elseif (\array_key_exists('UNTIL', $rrule)) {
+                            $objEvent->repeatEnd = $repeatEnd;
                             $recurrences = $this->calculateRecurrenceCount($objEvent);
                         }
                         $objEvent->recurrences = $recurrences;


### PR DESCRIPTION
The recurrence count is always 0 since the the method, that calculates it, needs $objEvent->repeatEnd set, but it was not set. This PR set $objEvent->repeatEnd so recurrences count can be calculated.