### PR TITLE
Don't use 'fields' as translation field

### DIFF
--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/dca/tl_calendar.php
+++ b/contao/dca/tl_calendar.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/dca/tl_calendar_events.php
+++ b/contao/dca/tl_calendar_events.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/dca/tl_content.php
+++ b/contao/dca/tl_content.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/dca/tl_page.php
+++ b/contao/dca/tl_page.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/de/default.php
+++ b/contao/languages/de/default.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_calendar.php
+++ b/contao/languages/de/tl_calendar.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_calendar_events.php
+++ b/contao/languages/de/tl_calendar_events.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_content.php
+++ b/contao/languages/de/tl_content.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_page.php
+++ b/contao/languages/de/tl_page.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/en/default.php
+++ b/contao/languages/en/default.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/en/tl_calendar.php
+++ b/contao/languages/en/tl_calendar.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/en/tl_calendar_events.php
+++ b/contao/languages/en/tl_calendar_events.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/en/tl_content.php
+++ b/contao/languages/en/tl_content.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/contao/languages/en/tl_page.php
+++ b/contao/languages/en/tl_page.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Backend/Automator.php
+++ b/src/Backend/Automator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Backend/ExportController.php
+++ b/src/Backend/ExportController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/CgoitContaoCalendarIcalBundle.php
+++ b/src/CgoitContaoCalendarIcalBundle.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Controller/ContentElement/ContentIcalElement.php
+++ b/src/Controller/ContentElement/ContentIcalElement.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Controller/Page/IcsFeedController.php
+++ b/src/Controller/Page/IcsFeedController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Controller/Route/EventlistIcsExportController.php
+++ b/src/Controller/Route/EventlistIcsExportController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Controller/Route/SingleEventIcsExportController.php
+++ b/src/Controller/Route/SingleEventIcsExportController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Cron/GenerateSubscriptionsCron.php
+++ b/src/Cron/GenerateSubscriptionsCron.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Cron/ImportCalendarsFromIcsCron.php
+++ b/src/Cron/ImportCalendarsFromIcsCron.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/DependencyInjection/CgoitContaoCalendarIcalExtension.php
+++ b/src/DependencyInjection/CgoitContaoCalendarIcalExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Event/AfterImportItemEvent.php
+++ b/src/Event/AfterImportItemEvent.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Event/BeforeImportItemEvent.php
+++ b/src/Event/BeforeImportItemEvent.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarDeleteListener.php
+++ b/src/EventListener/DataContainer/CalendarDeleteListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarEventsLoadListener.php
+++ b/src/EventListener/DataContainer/CalendarEventsLoadListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarEventsSubmitListener.php
+++ b/src/EventListener/DataContainer/CalendarEventsSubmitListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarHeaderCallback.php
+++ b/src/EventListener/DataContainer/CalendarHeaderCallback.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarIcalAliasSaveListener.php
+++ b/src/EventListener/DataContainer/CalendarIcalAliasSaveListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarOptionsListener.php
+++ b/src/EventListener/DataContainer/CalendarOptionsListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/CalendarSubmitListener.php
+++ b/src/EventListener/DataContainer/CalendarSubmitListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/PageListener.php
+++ b/src/EventListener/DataContainer/PageListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/GetAllEventsListener.php
+++ b/src/EventListener/GetAllEventsListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2024, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventListener/RobotsTxtEventListener.php
+++ b/src/EventListener/RobotsTxtEventListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/EventSubscriber/AddBackendAssetsSubscriber.php
+++ b/src/EventSubscriber/AddBackendAssetsSubscriber.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2024, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Import/Csv/Csv.php
+++ b/src/Import/Csv/Csv.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Import/Csv/CsvParser.php
+++ b/src/Import/Csv/CsvParser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Import/Csv/CsvReader.php
+++ b/src/Import/Csv/CsvReader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2023, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Util/ResponseUtil.php
+++ b/src/Util/ResponseUtil.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Util/TimezoneUtil.php
+++ b/src/Util/TimezoneUtil.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */

--- a/src/Util/TimezoneUtilAwareInterface.php
+++ b/src/Util/TimezoneUtilAwareInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of cgoit\contao-calendar-ical-bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2025, cgoIT
+ * @copyright  Copyright (c) 2026, cgoIT
  * @author     cgoIT <https://cgo-it.de>
  * @license    LGPL-3.0-or-later
  */


### PR DESCRIPTION
This could cause problems with Dome other extensions, If they User the naming scheme of the  DCA in Langusten Files, because 'field' is often used as name of the fields array. (Changes see: 03cc0f3, 570738f)