### PR TITLE
Fix recurrence count calculation on edge cases

### DIFF
--- a/src/Import/IcsImport.php
+++ b/src/Import/IcsImport.php
@@ -616,7 +616,7 @@ class IcsImport extends AbstractImport
             }
         }
 
-        if ($repeatCount === 0) {
+        if (0 === $repeatCount) {
             // in this case the end date is before the first recurrence
             // we need to set the event to non-recurring as 0 would mean that the event recurs infinitely
             $objEvent->recurring = false;


### PR DESCRIPTION
Today I had the strange issue, that an old event was repeated in calendar. I found out, that the event in the ical source had repeat on, but it ended before the first repeat would occur. But this edge case lead to calculating 0 recurrenses in the bundle, so it is endlessly repeating. 

This PR add a fix for this issue :)